### PR TITLE
BF5WW-172 - Revisar mensaje de "este evento genera interés"

### DIFF
--- a/cd2024bfs5g1-frontend/src/main/ngx/src/app/main/events/events-detail/events-detail.component.ts
+++ b/cd2024bfs5g1-frontend/src/main/ngx/src/app/main/events/events-detail/events-detail.component.ts
@@ -172,7 +172,6 @@ export class EventsDetailComponent implements OnInit {
             cantidadPlazasLibres = this.bookingEvents.availableEventBookings / this.bookingEvents.totalEventBookings;
             this.literalNumeroPlazas = "BOOKINGS_LEFT"
             this.numeroPlazas = this.bookingEvents.availableEventBookings;
-            console.log(this.numeroPlazas)
             switch (true) {
               case (cantidadPlazasLibres > 0.9):
                 this.literalPlazas = "EVENT_DISPONIBILITY_GT_90";

--- a/cd2024bfs5g1-frontend/src/main/ngx/src/app/main/events/events-detail/events-detail.component.ts
+++ b/cd2024bfs5g1-frontend/src/main/ngx/src/app/main/events/events-detail/events-detail.component.ts
@@ -172,8 +172,8 @@ export class EventsDetailComponent implements OnInit {
             cantidadPlazasLibres = this.bookingEvents.availableEventBookings / this.bookingEvents.totalEventBookings;
             this.literalNumeroPlazas = "BOOKINGS_LEFT"
             this.numeroPlazas = this.bookingEvents.availableEventBookings;
+            console.log(this.numeroPlazas)
             switch (true) {
-
               case (cantidadPlazasLibres > 0.9):
                 this.literalPlazas = "EVENT_DISPONIBILITY_GT_90";
                 break;

--- a/cd2024bfs5g1-frontend/src/main/ngx/src/assets/i18n/en.json
+++ b/cd2024bfs5g1-frontend/src/main/ngx/src/assets/i18n/en.json
@@ -208,7 +208,7 @@
   "DAY": "Day",
   "WEEK": "Week",
   "MONTH": "Month",
-  "EVENT_DISPONIBILITY_GT_90": "This event generates interest",
+  "EVENT_DISPONIBILITY_GT_90": "This event generates little interest",
   "EVENT_DISPONIBILITY_GT_65": "This event is starting to fill up",
   "EVENT_DISPONIBILITY_GT_50": "Be here or not be here, this is the question",
   "EVENT_DISPONIBILITY_GT_30": "Quite plenty of people",

--- a/cd2024bfs5g1-frontend/src/main/ngx/src/assets/i18n/es.json
+++ b/cd2024bfs5g1-frontend/src/main/ngx/src/assets/i18n/es.json
@@ -208,7 +208,7 @@
   "DAY": "Día",
   "WEEK": "Semana",
   "MONTH": "Mes",
-  "EVENT_DISPONIBILITY_GT_90": "Parece que este evento genera interés",
+  "EVENT_DISPONIBILITY_GT_90": "Este evento genera poco interés",
   "EVENT_DISPONIBILITY_GT_65": "Apúntate que esto empieza a llenarse",
   "EVENT_DISPONIBILITY_GT_50": "Asistir o no asistir, esta es la cuestión",
   "EVENT_DISPONIBILITY_GT_30": "No esperes más, casi está lleno",


### PR DESCRIPTION
Descripción

Cambiar el mensaje de “este evento genera interés “por otro mientras no tenga reservas.